### PR TITLE
Update kraken.nf

### DIFF
--- a/modules/local/kraken.nf
+++ b/modules/local/kraken.nf
@@ -29,7 +29,7 @@ process KRAKEN2_CLASSIFY {
         --threads $task.cpus \\
         --output ${meta.id}-classified.tsv \\
         --report ${meta.id}-kreport.tsv \\
-        --memory-mapping
+        --memory-mapping \\
         --db $db \\
         $reads
 

--- a/modules/local/kraken.nf
+++ b/modules/local/kraken.nf
@@ -29,6 +29,7 @@ process KRAKEN2_CLASSIFY {
         --threads $task.cpus \\
         --output ${meta.id}-classified.tsv \\
         --report ${meta.id}-kreport.tsv \\
+        --memory-mapping
         --db $db \\
         $reads
 


### PR DESCRIPTION
Hi Darian,

thanks for this great pipeline. This pull request is to prevent the following memory error message:

```
Loading database information...Failed attempt to allocate 74692466100bytes;
  you may not have enough free memory to load this database.
  If your computer has enough RAM, perhaps reducing memory usage from
  other programs could help you load this database?
  classify: unable to allocate hash table memory
```